### PR TITLE
feat: persiste result as ChangeEntry in Zeno

### DIFF
--- a/apps/github-agent/package.json
+++ b/apps/github-agent/package.json
@@ -36,6 +36,7 @@
     "@temporalio/worker": "1.11.7",
     "@temporalio/workflow": "1.11.7",
     "@vertesia/client": "^0.50.1",
+    "@vertesia/common": "^0.55.0",
     "octokit": "4.1.2"
   }
 }

--- a/apps/github-agent/package.json
+++ b/apps/github-agent/package.json
@@ -35,7 +35,7 @@
     "@temporalio/activity": "1.11.7",
     "@temporalio/worker": "1.11.7",
     "@temporalio/workflow": "1.11.7",
-    "@vertesia/client": "^0.50.1",
+    "@vertesia/client": "^0.55.0",
     "@vertesia/common": "^0.55.0",
     "octokit": "4.1.2"
   }

--- a/apps/github-agent/src/activities.ts
+++ b/apps/github-agent/src/activities.ts
@@ -625,7 +625,7 @@ export async function createChangeEntry(request: VertesiaCreateChangeEntryReques
             number: request.pullRequest.number,
             html_url: request.pullRequest.htmlUrl,
             owner: request.pullRequest.owner,
-            repository: request.pullRequest.owner,
+            repository: request.pullRequest.repository,
             repository_full_name: request.pullRequest.repositoryFullName,
         },
         author: {

--- a/apps/github-agent/src/activities.ts
+++ b/apps/github-agent/src/activities.ts
@@ -1,7 +1,13 @@
 import { log } from "@temporalio/activity";
+import { UploadContentObjectPayload } from "@vertesia/client";
+import { ContentObjectStatus } from '@vertesia/common';
 import { VertesiaGithubApp } from "./activities/github.js";
 import { HunkSet } from './activities/patch.js';
-import { createVertesiaClient } from './activities/vertesia.js';
+import {
+    ContentTypes,
+    createVertesiaClient,
+    VertesiaStore_ChangeEntry,
+} from './activities/vertesia.js';
 
 export async function helloActivity() {
     log.info("Hello, World!");
@@ -584,4 +590,68 @@ export async function getGuideline(request: GetGuidelineRequest): Promise<GetGui
     }
 
     return { content: "", error: "Error getting guideline: All fallback files failed." };
+}
+
+export type VertesiaCreateChangeEntryRequest = {
+    pullRequest: {
+        htmlUrl: string,
+        owner: string,
+        repository: string,
+        number: number,
+        repositoryFullName: string,
+    },
+    commit: {
+        sha: string,
+        date: string,
+        dateInSecond: number,
+    },
+    author: {
+        userId: string,
+        date: string,
+        dateInSecond: number,
+    },
+    title: string,
+    description: string,
+    tags: string[],
+}
+export type VertesiaCreateChangeEntryResponse = {
+    changeEntryId: string,
+    changeEntryUrl: string,
+}
+export async function createChangeEntry(request: VertesiaCreateChangeEntryRequest): Promise<VertesiaCreateChangeEntryResponse> {
+    const client = (await createVertesiaClient()).baseClient;
+    const props: VertesiaStore_ChangeEntry = {
+        pull_request: {
+            number: request.pullRequest.number,
+            html_url: request.pullRequest.htmlUrl,
+            owner: request.pullRequest.owner,
+            repository: request.pullRequest.owner,
+            repository_full_name: request.pullRequest.repositoryFullName,
+        },
+        author: {
+            user_id: request.author.userId,
+            date: request.author.date,
+        },
+    };
+
+    const payload: UploadContentObjectPayload = {
+        type: ContentTypes.ChangeEntry,
+        name: request.title,
+        text: request.description,
+        properties: { ...props },
+        tags: request.tags,
+    };
+    const creationResponse = await client.objects.create(payload);
+
+    // We don't use the "Standard Document Intake" for processing the object because we don't
+    // any blobs to be created. We just use the metadata of the object. So we mark the object
+    // as completed.
+    await client.store.objects.update(creationResponse.id, {
+        status: ContentObjectStatus.completed,
+    });
+
+    return {
+        changeEntryId: creationResponse.id,
+        changeEntryUrl: `https://preview.cloud.vertesia.io/store/objects/${creationResponse.id}`,
+    };
 }

--- a/apps/github-agent/src/activities.ts
+++ b/apps/github-agent/src/activities.ts
@@ -638,6 +638,7 @@ export async function createChangeEntry(request: VertesiaCreateChangeEntryReques
         type: ContentTypes.ChangeEntry,
         name: request.title,
         text: request.description,
+        location: `${request.pullRequest.repositoryFullName}/changes/${request.pullRequest.number}`,
         properties: { ...props },
         tags: request.tags,
     };

--- a/apps/github-agent/src/activities/vertesia.ts
+++ b/apps/github-agent/src/activities/vertesia.ts
@@ -9,8 +9,11 @@
  *   - SubType is an optional suffix to the type, used for a nested structure
  */
 import { createSecretProvider, SupportedCloudEnvironments } from '@dglabs/cloud';
-import { VertesiaClient as VertesiaBaseClient } from "@vertesia/client";
 import { log } from '@temporalio/activity';
+import {
+    UploadContentObjectPayload,
+    VertesiaClient as VertesiaBaseClient,
+} from "@vertesia/client";
 
 /**
  * Request to review a file patch.
@@ -88,29 +91,29 @@ export type VertesiaDeterminePullRequestPurposeResponse = {
 }
 
 export type VertesiaCreateChangeEntryRequest = {
-    pull_request: {
-        html_url: string,
+    pullRequest: {
+        htmlUrl: string,
         owner: string,
         repository: string,
         number: number,
-        repository_full_name: string,
+        repositoryFullName: string,
     },
     commit: {
         sha: string,
         date: string,
-        date_in_second: number,
+        dateInSecond: number,
     },
     author: {
-        user_id: string,
+        userId: string,
         date: string,
-        date_in_second: number,
+        dateInSecond: number,
     },
     description: string,
     tags: string[],
 }
 export type VertesiaCreateChangeEntryResponse = {
-    change_entry_id: string,
-    change_entry_url: string,
+    changeEntryId: string,
+    changeEntryUrl: string,
 }
 
 export class VertesiaClient {
@@ -186,7 +189,15 @@ export class VertesiaClient {
     async createChangeEntry(request: VertesiaCreateChangeEntryRequest): Promise<VertesiaCreateChangeEntryResponse> {
         // TODO: we cannot use the Objects API from Zeno because it does not support creating objects without
         // a file. We need to create a new endpoint for this.
-        return undefined as any;
+        const payload: UploadContentObjectPayload = {
+            type: '6821524ef3aed394f1ec4931', // ChangeEntry
+        }
+        const resp = await this.client.store.objects.create(payload);
+
+        return {
+            changeEntryId: resp.id,
+            changeEntryUrl: `https://studio-preview.api.vertesia.io/${resp.id}`,
+        };
     }
 
     private logResult(executionEndpoint: string, request: any, response: any) {

--- a/apps/github-agent/src/activities/vertesia.ts
+++ b/apps/github-agent/src/activities/vertesia.ts
@@ -87,6 +87,32 @@ export type VertesiaDeterminePullRequestPurposeResponse = {
     clearness: number, // 1-5
 }
 
+export type VertesiaCreateChangeEntryRequest = {
+    pull_request: {
+        html_url: string,
+        owner: string,
+        repository: string,
+        number: number,
+        repository_full_name: string,
+    },
+    commit: {
+        sha: string,
+        date: string,
+        date_in_second: number,
+    },
+    author: {
+        user_id: string,
+        date: string,
+        date_in_second: number,
+    },
+    description: string,
+    tags: string[],
+}
+export type VertesiaCreateChangeEntryResponse = {
+    change_entry_id: string,
+    change_entry_url: string,
+}
+
 export class VertesiaClient {
     private client: VertesiaBaseClient;
 
@@ -155,6 +181,12 @@ export class VertesiaClient {
         );
         this.logResult(endpoint, request, response);
         return response.result;
+    }
+
+    async createChangeEntry(request: VertesiaCreateChangeEntryRequest): Promise<VertesiaCreateChangeEntryResponse> {
+        // TODO: we cannot use the Objects API from Zeno because it does not support creating objects without
+        // a file. We need to create a new endpoint for this.
+        return undefined as any;
     }
 
     private logResult(executionEndpoint: string, request: any, response: any) {

--- a/apps/github-agent/src/activities/vertesia.ts
+++ b/apps/github-agent/src/activities/vertesia.ts
@@ -14,12 +14,9 @@
  */
 import { createSecretProvider, SupportedCloudEnvironments } from '@dglabs/cloud';
 import { log } from '@temporalio/activity';
-import {
-    UploadContentObjectPayload,
-    VertesiaClient as VertesiaBaseClient,
-} from "@vertesia/client";
+import { VertesiaClient as VertesiaBaseClient } from "@vertesia/client";
 
-enum ContentTypes {
+export enum ContentTypes {
     /**
      * The ID of the content type "ChangeEntry".
      *
@@ -103,33 +100,6 @@ export type VertesiaDeterminePullRequestPurposeResponse = {
     clearness: number, // 1-5
 }
 
-export type VertesiaCreateChangeEntryRequest = {
-    pullRequest: {
-        htmlUrl: string,
-        owner: string,
-        repository: string,
-        number: number,
-        repositoryFullName: string,
-    },
-    commit: {
-        sha: string,
-        date: string,
-        dateInSecond: number,
-    },
-    author: {
-        userId: string,
-        date: string,
-        dateInSecond: number,
-    },
-    title: string,
-    description: string,
-    tags: string[],
-}
-export type VertesiaCreateChangeEntryResponse = {
-    changeEntryId: string,
-    changeEntryUrl: string,
-}
-
 export type VertesiaStore_ChangeEntry = {
     /**
      * The pull request related to this change entry.
@@ -189,6 +159,10 @@ export class VertesiaClient {
 
     constructor(client: VertesiaBaseClient) {
         this.client = client;
+    }
+
+    get baseClient(): VertesiaBaseClient {
+        return this.client;
     }
 
     /**
@@ -252,35 +226,6 @@ export class VertesiaClient {
         );
         this.logResult(endpoint, request, response);
         return response.result;
-    }
-
-    async createChangeEntry(request: VertesiaCreateChangeEntryRequest): Promise<VertesiaCreateChangeEntryResponse> {
-        const props: VertesiaStore_ChangeEntry = {
-            pull_request: {
-                number: request.pullRequest.number,
-                html_url: request.pullRequest.htmlUrl,
-                owner: request.pullRequest.owner,
-                repository: request.pullRequest.owner,
-                repository_full_name: request.pullRequest.repositoryFullName,
-            },
-            author: {
-                user_id: request.author.userId,
-                date: request.author.date,
-            },
-        };
-        const payload: UploadContentObjectPayload = {
-            type: ContentTypes.ChangeEntry,
-            name: request.title,
-            text: request.description,
-            properties: { ...props },
-            tags: request.tags,
-        };
-        const resp = await this.client.store.objects.create(payload);
-
-        return {
-            changeEntryId: resp.id,
-            changeEntryUrl: `https://studio-preview.api.vertesia.io/store/objects/${resp.id}`,
-        };
     }
 
     private logResult(executionEndpoint: string, request: any, response: any) {

--- a/apps/github-agent/src/workflows/review-pull-request.ts
+++ b/apps/github-agent/src/workflows/review-pull-request.ts
@@ -85,6 +85,11 @@ export async function assistPullRequestWorkflow(request: AssistPullRequestWorkfl
 
     await condition(() => prEvent.pull_request.state === 'closed' || prEvent.pull_request.merged);
 
+    // TODO: persist results into zeno
+    if (patched('use-zeno-for-pull-request')) {
+
+    }
+
     const status = prEvent.pull_request.merged ? 'merged' : 'closed';
     log.info(`Pull request is ${status} (state: ${prEvent.pull_request.state}, merged: ${prEvent.pull_request.merged})`, { pull_request_ctx: ctx });
     return {

--- a/apps/github-agent/src/workflows/review-pull-request.ts
+++ b/apps/github-agent/src/workflows/review-pull-request.ts
@@ -92,6 +92,10 @@ export async function assistPullRequestWorkflow(request: AssistPullRequestWorkfl
         if (prEvent.pull_request.merged && isUserEnabled) {
             log.info('Creating a change entry for the pull request', { pull_request_ctx: ctx });
             try {
+                let description = ctx.pullRequest.motivation ?? '';
+                description += '\n\n' + (ctx.pullRequest.context ?? '');
+                description = description.trim();
+
                 const resp = await createChangeEntry({
                     pullRequest: {
                         number: Number(prEvent.pull_request.number),
@@ -111,10 +115,8 @@ export async function assistPullRequestWorkflow(request: AssistPullRequestWorkfl
                         dateInSecond: Math.floor(new Date(prEvent.pull_request.updated_at).getTime() / 1000),
                     },
                     title: prEvent.pull_request.title,
-                    description: prEvent.pull_request.body,
-                    tags: [
-                        'app:studio-server',
-                    ], // TODO
+                    description: description,
+                    tags: [], // TODO
                 })
                 log.info('Created a change entry', { change_entry: resp });
             } catch (err) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,8 +32,8 @@ importers:
         specifier: 1.11.7
         version: 1.11.7
       '@vertesia/client':
-        specifier: ^0.50.1
-        version: 0.50.1
+        specifier: ^0.55.0
+        version: 0.55.0
       '@vertesia/common':
         specifier: ^0.55.0
         version: 0.55.0
@@ -1111,11 +1111,11 @@ packages:
   '@vercel/static-config@3.0.0':
     resolution: {integrity: sha512-2qtvcBJ1bGY0dYGYh3iM7yGKkk971FujLEDXzuW5wcZsPr1GSEjO/w2iSr3qve6nDDtBImsGoDEnus5FI4+fIw==}
 
-  '@vertesia/api-fetch-client@0.50.1':
-    resolution: {integrity: sha512-X3fUkzbGIwqVjCwXShKzyBFxkzv0KNIW2BICbFi+OqZpZuS0sh0DtdUiXr3t3jzKbLpzv0BsaA37gt4143AFsw==}
+  '@vertesia/api-fetch-client@0.55.0':
+    resolution: {integrity: sha512-O+Oqn9834nSUBv9CTcGcnCSD55oxP/TP3Lc7YA42biIoDhe5UGk6XnMLSGku7cn/OracWCe47dMQOwIv7i5NIg==}
 
-  '@vertesia/client@0.50.1':
-    resolution: {integrity: sha512-QG0VHBhJbjYKLsR+XrZa1Lj1rF518NxAQDrE7hZJAnFQQObaWa0yn3F9M6gFX2zZ/+LGIqhj/VS21ITa6ZzI3w==}
+  '@vertesia/client@0.55.0':
+    resolution: {integrity: sha512-IE/2pyzQ9WEXQRipehHLHisgPPLzd2pfHuYK9//ENfC1FGyXy8sREh5vq7hBrNsMkMPiU8rkQN/dOR1yjKKSvQ==}
 
   '@vertesia/common@0.50.1':
     resolution: {integrity: sha512-yF6YcxS9zBGEYUUYKLHuKMj75E8qFBEu12aZbBJ/7PZ6tFUyFOuKZrYy59fwGRUWhzhWpHb4D5I2BytsVcsV/Q==}
@@ -1604,9 +1604,13 @@ packages:
     resolution: {integrity: sha512-v0eOBUbiaFojBu2s2NPBfYUoRR9GjcDNvCXVaqEf5vVfpIAh9f8RCo4vXTP8c63QRKCFwoLpMpTdPwwhEKVgzA==}
     engines: {node: '>=14.18'}
 
-  eventsource@2.0.2:
-    resolution: {integrity: sha512-IzUmBGPR3+oUG9dUeXynyNmf91/3zUSJg1lCktzKw47OXuhco54U3r9B7O4XX+Rb1Itm9OZ2b0RkTs10bICOxA==}
-    engines: {node: '>=12.0.0'}
+  eventsource-parser@3.0.1:
+    resolution: {integrity: sha512-VARTJ9CYeuQYb0pZEPbzi740OWFgpHe7AYJ2WFZVnUDUQp5Dk2yJUgF36YsZ81cOyxT0QxmXD2EQpapAouzWVA==}
+    engines: {node: '>=18.0.0'}
+
+  eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
+    engines: {node: '>=18.0.0'}
 
   expect-type@1.1.0:
     resolution: {integrity: sha512-bFi65yM+xZgk+u/KRIpekdSYkTB5W1pEf0Lt8Q8Msh7b+eQ7LXVtIB1Bkm4fvclDEL1b2CZkMhv2mOeF8tMdkA==}
@@ -4260,16 +4264,16 @@ snapshots:
       json-schema-to-ts: 1.6.4
       ts-morph: 12.0.0
 
-  '@vertesia/api-fetch-client@0.50.1':
+  '@vertesia/api-fetch-client@0.55.0':
     dependencies:
       eventsource-parser: 1.1.2
 
-  '@vertesia/client@0.50.1':
+  '@vertesia/client@0.55.0':
     dependencies:
-      '@llumiverse/core': 0.15.0
-      '@vertesia/api-fetch-client': 0.50.1
-      '@vertesia/common': 0.50.1
-      eventsource: 2.0.2
+      '@llumiverse/core': 0.17.0
+      '@vertesia/api-fetch-client': 0.55.0
+      '@vertesia/common': 0.55.0
+      eventsource: 3.0.7
 
   '@vertesia/common@0.50.1':
     dependencies:
@@ -4798,7 +4802,11 @@ snapshots:
 
   eventsource-parser@1.1.2: {}
 
-  eventsource@2.0.2: {}
+  eventsource-parser@3.0.1: {}
+
+  eventsource@3.0.7:
+    dependencies:
+      eventsource-parser: 3.0.1
 
   expect-type@1.1.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,6 +34,9 @@ importers:
       '@vertesia/client':
         specifier: ^0.50.1
         version: 0.50.1
+      '@vertesia/common':
+        specifier: ^0.55.0
+        version: 0.55.0
       octokit:
         specifier: 4.1.2
         version: 4.1.2
@@ -480,6 +483,9 @@ packages:
 
   '@llumiverse/core@0.15.0':
     resolution: {integrity: sha512-MDTHapYicYP+p0vpcc98njXey2F+hWtGc+gnWzS4ufU+vxYkL4DfBpeOF9O00Bg/hTxzGdxv0BYRcY88hqpk6g==}
+
+  '@llumiverse/core@0.17.0':
+    resolution: {integrity: sha512-hxfwnF9v4n1PfdbJoJhNdizNkZd6kQ5GmrmdEKHA96NvwMxj63rdb+Y/6iArh8UBTlwQgeIuyPVPqK+k05yPsw==}
 
   '@mapbox/node-pre-gyp@2.0.0':
     resolution: {integrity: sha512-llMXd39jtP0HpQLVI37Bf1m2ADlEb35GYSh1SDSLsBhR+5iCxiNGlT31yqbNtVHygHAtMy6dWFERpU2JgufhPg==}
@@ -1114,6 +1120,9 @@ packages:
   '@vertesia/common@0.50.1':
     resolution: {integrity: sha512-yF6YcxS9zBGEYUUYKLHuKMj75E8qFBEu12aZbBJ/7PZ6tFUyFOuKZrYy59fwGRUWhzhWpHb4D5I2BytsVcsV/Q==}
 
+  '@vertesia/common@0.55.0':
+    resolution: {integrity: sha512-dXdQrPtd1u7t8mVHrO2qS248TwsEHgKEPjfGJB1KrONVvpB0WrCOzXzBWyPs0IUJ2eQgXGFHYrEWZoVeQ95qOA==}
+
   '@vitest/expect@2.1.9':
     resolution: {integrity: sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==}
 
@@ -1342,6 +1351,7 @@ packages:
   bson@6.10.1:
     resolution: {integrity: sha512-P92xmHDQjSKPLHqFxefqMxASNq/aWJMEZugpCjf+AF/pgcUpMMQCg7t7+ewko0/u8AapvF3luf/FoehddEK+sA==}
     engines: {node: '>=16.20.1'}
+    deprecated: a critical bug affecting only useBigInt64=true deserialization usage is fixed in bson@6.10.3
 
   buffer-equal-constant-time@1.0.1:
     resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
@@ -1978,6 +1988,11 @@ packages:
   mime-types@2.1.35:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
+
+  mime@4.0.7:
+    resolution: {integrity: sha512-2OfDPL+e03E0LrXaGYOtTFIYhiuzep94NSsuhrNULq+stylcJedcHdzHtz0atMUuGwJfFYs0YL5xeC/Ca2x0eQ==}
+    engines: {node: '>=16'}
+    hasBin: true
 
   minimatch@10.0.1:
     resolution: {integrity: sha512-ethXTt3SGGR+95gudmqJ1eNhRO7eGEGIgYA9vnPatK4/etz2MEVDno5GMCibdMTuBMyElzIlgxMna3K94XDIDQ==}
@@ -3456,6 +3471,12 @@ snapshots:
       ajv: 8.17.1
       ajv-formats: 3.0.1(ajv@8.17.1)
 
+  '@llumiverse/core@0.17.0':
+    dependencies:
+      '@types/node': 22.13.1
+      ajv: 8.17.1
+      ajv-formats: 3.0.1(ajv@8.17.1)
+
   '@mapbox/node-pre-gyp@2.0.0':
     dependencies:
       consola: 3.4.0
@@ -4255,6 +4276,13 @@ snapshots:
       '@llumiverse/core': 0.15.0
       ajv: 8.17.1
       json-schema: 0.4.0
+
+  '@vertesia/common@0.55.0':
+    dependencies:
+      '@llumiverse/core': 0.17.0
+      ajv: 8.17.1
+      json-schema: 0.4.0
+      mime: 4.0.7
 
   '@vitest/expect@2.1.9':
     dependencies:
@@ -5191,6 +5219,8 @@ snapshots:
   mime-types@2.1.35:
     dependencies:
       mime-db: 1.52.0
+
+  mime@4.0.7: {}
 
   minimatch@10.0.1:
     dependencies:


### PR DESCRIPTION
This PR ensures that a pull request summary persists in Vertesia's content store as a ChangeEntry. This is useful for creating release notes.