### PR TITLE
fix: remove issue parsing from branch name

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -25,7 +25,7 @@ jobs:
         cache: pnpm
     - name: Authenticate to NPM registry
       run: |
-        npm install -g @vertesia/cli
+        npm install -g @vertesia/cli@0.50.1
         vertesia --version
         vertesia profiles create "${VT_PROFILE}" \
             --target "${VT_ENV}" \

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -26,6 +26,7 @@ jobs:
     - name: Authenticate to NPM registry
       run: |
         npm install -g @vertesia/cli
+        vertesia --version
         vertesia profiles create "${VT_PROFILE}" \
             --target "${VT_ENV}" \
             --account "${VT_ACCOUNT}" \

--- a/.gitignore
+++ b/.gitignore
@@ -132,3 +132,4 @@ dist
 # Vertesia
 lib/
 .npmrc
+.turbo

--- a/apps/github-agent/package.json
+++ b/apps/github-agent/package.json
@@ -35,8 +35,8 @@
     "@temporalio/activity": "1.11.7",
     "@temporalio/worker": "1.11.7",
     "@temporalio/workflow": "1.11.7",
-    "@vertesia/client": "^0.55.0",
-    "@vertesia/common": "^0.55.0",
+    "@vertesia/client": "0.50.1",
+    "@vertesia/common": "0.50.1",
     "octokit": "4.1.2"
   }
 }

--- a/apps/github-agent/src/workflows/parser.test.ts
+++ b/apps/github-agent/src/workflows/parser.test.ts
@@ -1,23 +1,5 @@
 import { expect, test } from 'vitest';
-import {
-    parseIssueIdFromBranch,
-    parseIssueIdsFromComment,
-} from './parser';
-import { GithubIssueRef } from './types.js';
-
-test('Parse issue ID from Git branch', async () => {
-    expect(parseIssueIdFromBranch({
-        org: 'vertesia',
-        repo: 'studio',
-        branch: 'feat/123/my-feature',
-    })).toEqual(new GithubIssueRef('vertesia', 'studio', 123));
-
-    expect(parseIssueIdFromBranch({
-        org: 'vertesia',
-        repo: 'studio',
-        branch: 'feat-123',
-    })).toEqual(new GithubIssueRef('vertesia', 'studio', 123));
-});
+import { parseIssueIdsFromComment } from './parser';
 
 test('Parse issue ID from comment', async () => {
     expect(parseIssueIdsFromComment({

--- a/apps/github-agent/src/workflows/parser.ts
+++ b/apps/github-agent/src/workflows/parser.ts
@@ -1,17 +1,5 @@
 import { GithubIssueRef } from './types.js';
 
-export function parseIssueIdFromBranch({ org, repo, branch }: { org: string, repo: string, branch: string }): GithubIssueRef | undefined {
-    const match = branch.match(/(\d+)/);
-    if (match === null) {
-        return undefined;
-    }
-    const number = parseInt(match[1], 10);
-    if (isNaN(number)) {
-        return undefined;
-    }
-    return new GithubIssueRef(org, repo, number);
-}
-
 export function parseIssueIdsFromComment({ org, repo, comment }: { org: string, repo: string, comment: string }): Record<string, GithubIssueRef> {
     // key: html URL, value: issue reference
     const issues: Record<string, GithubIssueRef> = {};
@@ -46,10 +34,5 @@ export function parseIssueIdsFromComment({ org, repo, comment }: { org: string, 
 
 export function parseIssuesFromPullRequest({ org, repo, branch, body }: { org: string, repo: string, branch: string, body: string }): GithubIssueRef[] {
     const issues = parseIssueIdsFromComment({ org, repo, comment: body });
-    const issue = parseIssueIdFromBranch({ org, repo, branch });
-    if (issue !== undefined) {
-        issues[issue.toHtmlUrl()] = issue;
-    }
-
     return Object.values(issues);
 }

--- a/apps/github-agent/src/workflows/parser.ts
+++ b/apps/github-agent/src/workflows/parser.ts
@@ -32,7 +32,7 @@ export function parseIssueIdsFromComment({ org, repo, comment }: { org: string, 
     return issues;
 }
 
-export function parseIssuesFromPullRequest({ org, repo, branch, body }: { org: string, repo: string, branch: string, body: string }): GithubIssueRef[] {
+export function parseIssuesFromPullRequest({ org, repo, body }: { org: string, repo: string, body: string }): GithubIssueRef[] {
     const issues = parseIssueIdsFromComment({ org, repo, comment: body });
     return Object.values(issues);
 }

--- a/apps/github-agent/src/workflows/review-pull-request.ts
+++ b/apps/github-agent/src/workflows/review-pull-request.ts
@@ -632,7 +632,6 @@ async function loadGithubIssues(ctx: AssistantContext) {
     const issueRefs = parseIssuesFromPullRequest({
         org: ctx.pullRequest.org,
         repo: ctx.pullRequest.repo,
-        branch: ctx.pullRequest.branch,
         body: ctx.pullRequest.body,
     });
     log.info(`Found ${issueRefs.length} GitHub issues in the pull request`, { pull_request_ctx: ctx, issue_refs: issueRefs });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,11 +32,11 @@ importers:
         specifier: 1.11.7
         version: 1.11.7
       '@vertesia/client':
-        specifier: ^0.55.0
-        version: 0.55.0
+        specifier: 0.50.1
+        version: 0.50.1
       '@vertesia/common':
-        specifier: ^0.55.0
-        version: 0.55.0
+        specifier: 0.50.1
+        version: 0.50.1
       octokit:
         specifier: 4.1.2
         version: 4.1.2
@@ -483,9 +483,6 @@ packages:
 
   '@llumiverse/core@0.15.0':
     resolution: {integrity: sha512-MDTHapYicYP+p0vpcc98njXey2F+hWtGc+gnWzS4ufU+vxYkL4DfBpeOF9O00Bg/hTxzGdxv0BYRcY88hqpk6g==}
-
-  '@llumiverse/core@0.17.0':
-    resolution: {integrity: sha512-hxfwnF9v4n1PfdbJoJhNdizNkZd6kQ5GmrmdEKHA96NvwMxj63rdb+Y/6iArh8UBTlwQgeIuyPVPqK+k05yPsw==}
 
   '@mapbox/node-pre-gyp@2.0.0':
     resolution: {integrity: sha512-llMXd39jtP0HpQLVI37Bf1m2ADlEb35GYSh1SDSLsBhR+5iCxiNGlT31yqbNtVHygHAtMy6dWFERpU2JgufhPg==}
@@ -1111,17 +1108,14 @@ packages:
   '@vercel/static-config@3.0.0':
     resolution: {integrity: sha512-2qtvcBJ1bGY0dYGYh3iM7yGKkk971FujLEDXzuW5wcZsPr1GSEjO/w2iSr3qve6nDDtBImsGoDEnus5FI4+fIw==}
 
-  '@vertesia/api-fetch-client@0.55.0':
-    resolution: {integrity: sha512-O+Oqn9834nSUBv9CTcGcnCSD55oxP/TP3Lc7YA42biIoDhe5UGk6XnMLSGku7cn/OracWCe47dMQOwIv7i5NIg==}
+  '@vertesia/api-fetch-client@0.50.1':
+    resolution: {integrity: sha512-X3fUkzbGIwqVjCwXShKzyBFxkzv0KNIW2BICbFi+OqZpZuS0sh0DtdUiXr3t3jzKbLpzv0BsaA37gt4143AFsw==}
 
-  '@vertesia/client@0.55.0':
-    resolution: {integrity: sha512-IE/2pyzQ9WEXQRipehHLHisgPPLzd2pfHuYK9//ENfC1FGyXy8sREh5vq7hBrNsMkMPiU8rkQN/dOR1yjKKSvQ==}
+  '@vertesia/client@0.50.1':
+    resolution: {integrity: sha512-QG0VHBhJbjYKLsR+XrZa1Lj1rF518NxAQDrE7hZJAnFQQObaWa0yn3F9M6gFX2zZ/+LGIqhj/VS21ITa6ZzI3w==}
 
   '@vertesia/common@0.50.1':
     resolution: {integrity: sha512-yF6YcxS9zBGEYUUYKLHuKMj75E8qFBEu12aZbBJ/7PZ6tFUyFOuKZrYy59fwGRUWhzhWpHb4D5I2BytsVcsV/Q==}
-
-  '@vertesia/common@0.55.0':
-    resolution: {integrity: sha512-dXdQrPtd1u7t8mVHrO2qS248TwsEHgKEPjfGJB1KrONVvpB0WrCOzXzBWyPs0IUJ2eQgXGFHYrEWZoVeQ95qOA==}
 
   '@vitest/expect@2.1.9':
     resolution: {integrity: sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==}
@@ -1604,13 +1598,9 @@ packages:
     resolution: {integrity: sha512-v0eOBUbiaFojBu2s2NPBfYUoRR9GjcDNvCXVaqEf5vVfpIAh9f8RCo4vXTP8c63QRKCFwoLpMpTdPwwhEKVgzA==}
     engines: {node: '>=14.18'}
 
-  eventsource-parser@3.0.1:
-    resolution: {integrity: sha512-VARTJ9CYeuQYb0pZEPbzi740OWFgpHe7AYJ2WFZVnUDUQp5Dk2yJUgF36YsZ81cOyxT0QxmXD2EQpapAouzWVA==}
-    engines: {node: '>=18.0.0'}
-
-  eventsource@3.0.7:
-    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
-    engines: {node: '>=18.0.0'}
+  eventsource@2.0.2:
+    resolution: {integrity: sha512-IzUmBGPR3+oUG9dUeXynyNmf91/3zUSJg1lCktzKw47OXuhco54U3r9B7O4XX+Rb1Itm9OZ2b0RkTs10bICOxA==}
+    engines: {node: '>=12.0.0'}
 
   expect-type@1.1.0:
     resolution: {integrity: sha512-bFi65yM+xZgk+u/KRIpekdSYkTB5W1pEf0Lt8Q8Msh7b+eQ7LXVtIB1Bkm4fvclDEL1b2CZkMhv2mOeF8tMdkA==}
@@ -1992,11 +1982,6 @@ packages:
   mime-types@2.1.35:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
-
-  mime@4.0.7:
-    resolution: {integrity: sha512-2OfDPL+e03E0LrXaGYOtTFIYhiuzep94NSsuhrNULq+stylcJedcHdzHtz0atMUuGwJfFYs0YL5xeC/Ca2x0eQ==}
-    engines: {node: '>=16'}
-    hasBin: true
 
   minimatch@10.0.1:
     resolution: {integrity: sha512-ethXTt3SGGR+95gudmqJ1eNhRO7eGEGIgYA9vnPatK4/etz2MEVDno5GMCibdMTuBMyElzIlgxMna3K94XDIDQ==}
@@ -3475,12 +3460,6 @@ snapshots:
       ajv: 8.17.1
       ajv-formats: 3.0.1(ajv@8.17.1)
 
-  '@llumiverse/core@0.17.0':
-    dependencies:
-      '@types/node': 22.13.1
-      ajv: 8.17.1
-      ajv-formats: 3.0.1(ajv@8.17.1)
-
   '@mapbox/node-pre-gyp@2.0.0':
     dependencies:
       consola: 3.4.0
@@ -4264,29 +4243,22 @@ snapshots:
       json-schema-to-ts: 1.6.4
       ts-morph: 12.0.0
 
-  '@vertesia/api-fetch-client@0.55.0':
+  '@vertesia/api-fetch-client@0.50.1':
     dependencies:
       eventsource-parser: 1.1.2
 
-  '@vertesia/client@0.55.0':
+  '@vertesia/client@0.50.1':
     dependencies:
-      '@llumiverse/core': 0.17.0
-      '@vertesia/api-fetch-client': 0.55.0
-      '@vertesia/common': 0.55.0
-      eventsource: 3.0.7
+      '@llumiverse/core': 0.15.0
+      '@vertesia/api-fetch-client': 0.50.1
+      '@vertesia/common': 0.50.1
+      eventsource: 2.0.2
 
   '@vertesia/common@0.50.1':
     dependencies:
       '@llumiverse/core': 0.15.0
       ajv: 8.17.1
       json-schema: 0.4.0
-
-  '@vertesia/common@0.55.0':
-    dependencies:
-      '@llumiverse/core': 0.17.0
-      ajv: 8.17.1
-      json-schema: 0.4.0
-      mime: 4.0.7
 
   '@vitest/expect@2.1.9':
     dependencies:
@@ -4802,11 +4774,7 @@ snapshots:
 
   eventsource-parser@1.1.2: {}
 
-  eventsource-parser@3.0.1: {}
-
-  eventsource@3.0.7:
-    dependencies:
-      eventsource-parser: 3.0.1
+  eventsource@2.0.2: {}
 
   expect-type@1.1.0: {}
 
@@ -5227,8 +5195,6 @@ snapshots:
   mime-types@2.1.35:
     dependencies:
       mime-db: 1.52.0
-
-  mime@4.0.7: {}
 
   minimatch@10.0.1:
     dependencies:


### PR DESCRIPTION
It's very error-prone, especially when the branch name contains a commit hash, which has one or multiple numbers.